### PR TITLE
Remove the copy constructor of the async network interface

### DIFF
--- a/src/router.hh
+++ b/src/router.hh
@@ -12,6 +12,7 @@
 // implementation of NetworkInterface.
 class AsyncNetworkInterface : public NetworkInterface
 {
+  AsyncNetworkInterface(const AsyncNetworkInterface&) = delete;
   std::queue<InternetDatagram> datagrams_in_ {};
 
 public:
@@ -61,7 +62,7 @@ public:
   // returns the index of the interface after it has been added to the router
   size_t add_interface( AsyncNetworkInterface&& interface )
   {
-    interfaces_.push_back( std::move( interface ) );
+    interfaces_.push_back( std::forward<AsyncNetworkInterface>( interface ) );
     return interfaces_.size() - 1;
   }
 


### PR DESCRIPTION
The netowrk interface shouldn't be copyable. The default copy constructor can lead to silent bugs, such as using:

```C++
AsyncNetworkInterface sender_interface = interface( re.interface_num );
```

And having the tests silently failing, when one should had used a reference, not a[n implicit] copy:

```C++
AsyncNetworkInterface &sender_interface = interface( re.interface_num );
```